### PR TITLE
Add new LineageOS default apps to icon overrides

### DIFF
--- a/src/scripts/iconPack.js
+++ b/src/scripts/iconPack.js
@@ -387,7 +387,8 @@ const iconPackConverter = [
             "com.zui.gallery",
             "jp.kyocera.kyoceradrmgallery",
             "org.codeaurora.gallery",
-            "org.mokee.venus"
+            "org.mokee.venus",
+            "org.lineageos.glimpse"
         ],
         "icon": "photos"
     },
@@ -427,6 +428,7 @@ const iconPackConverter = [
             "com.sonyericsson.music",
             "net.oneplus.music",
             "org.lineageos.eleven",
+            "org.lineageos.twelve",
             "com.huawei.music"
         ],
         "icon": "music",


### PR DESCRIPTION
Starting with LineageOS 21 and 22, LOS ships with new Gallery (`org.lineageos.glimpse`) and Music (`org.lineageos.twelve`) apps, respectively. This PR adds these to the icon overrides list.